### PR TITLE
[Fix] Fix wrong path

### DIFF
--- a/Modules/BooksDailyCheckin.sgmodule
+++ b/Modules/BooksDailyCheckin.sgmodule
@@ -3,7 +3,7 @@
 
 [Script]
 cron "10 0 * * *" script-path=https://raw.githubusercontent.com/jkgtw/Surge/master/JS/books-checkin.js, wake-system=1, timeout=5
-books-cookie.js = type=http-request,pattern=^https:\/\/myaccount\.books\.com\.tw\/myaccount\/myaccount\/getPercentcouponlist\/$,script-path=https://raw.githubusercontent.com/jkgtw/Surge/master/JS/books-cookie.js,script-update-interval=-1
+books-cookie.js = type=http-request,pattern=^https:\/\/myaccount\.books\.com\.tw\/myaccount\/myaccount\/getPercentcouponlist$,script-path=https://raw.githubusercontent.com/jkgtw/Surge/master/JS/books-cookie.js,script-update-interval=-1
 
 [MITM]
 hostname = %APPEND% myaccount.books.com.tw


### PR DESCRIPTION
抓 cookie 的路徑看起來有錯誤，沒有最後的 `/` ，修正過後可以正常抓取 cookie 了

![image](https://user-images.githubusercontent.com/78295747/159969696-4f4c63b0-797a-4e80-882b-091c09247df3.png)
